### PR TITLE
Llvm15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,9 +235,9 @@ dependencies = [
 
 [[package]]
 name = "inkwell"
-version = "0.1.0-beta.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2223d0eba0ae6d40a3e4680c6a3209143471e1f38b41746ea309aa36dde9f90b"
+checksum = "3f4fcb4a4fa0b8f7b4178e24e6317d6f8b95ab500d8e6e1bd4283b6860e369c1"
 dependencies = [
  "either",
  "inkwell_internals",
@@ -245,27 +245,17 @@ dependencies = [
  "llvm-sys",
  "once_cell",
  "parking_lot",
- "regex",
 ]
 
 [[package]]
 name = "inkwell_internals"
-version = "0.5.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c7090af3d300424caa81976b8c97bca41cd70e861272c072e188ae082fb49f9"
+checksum = "b185e7d068d6820411502efa14d8fbf010750485399402156b72dd2a548ef8e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -303,9 +293,9 @@ checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
 name = "llvm-sys"
-version = "130.0.4"
+version = "150.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb6ea20e8a348f6db0b43a7f009fa7d981d22edf4cbe2e0c7b2247dbb25be61"
+checksum = "6c31c2e6d67588f0877f9e625c3d9d74130af663399311319d0139fc4f3ea009"
 dependencies = [
  "cc",
  "lazy_static",
@@ -399,33 +389,31 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.12.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
- "instant",
  "lock_api",
  "parking_lot_core",
 ]
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.5"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
+checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
  "cfg-if",
- "instant",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "smallvec",
- "winapi",
+ "windows-targets",
 ]
 
 [[package]]
@@ -435,19 +423,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c520e05135d6e763148b6426a837e239041653ba7becd2e538c076c738025fc"
 
 [[package]]
-name = "pest"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
-dependencies = [
- "ucd-trie",
-]
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.39"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
+checksum = "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da"
 dependencies = [
  "unicode-ident",
 ]
@@ -460,9 +439,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.18"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
+checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
 dependencies = [
  "proc-macro2",
 ]
@@ -487,13 +466,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
  "getrandom",
- "redox_syscall",
+ "redox_syscall 0.2.13",
  "thiserror",
 ]
 
@@ -594,21 +582,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "semver"
-version = "0.11.0"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
-]
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
 
 [[package]]
 name = "serde"
@@ -624,7 +600,7 @@ checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.96",
 ]
 
 [[package]]
@@ -667,6 +643,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15e3fc8c0c74267e2df136e5e5fb656a464158aa57624053375eb9c8c6e25ae2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -701,14 +688,8 @@ checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.96",
 ]
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicode-ident"
@@ -800,12 +781,33 @@ version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "030b7ff91626e57a05ca64a07c481973cbb2db774e4852c9c7ca342408c6a99a"
 dependencies = [
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_msvc",
+ "windows_aarch64_msvc 0.30.0",
+ "windows_i686_gnu 0.30.0",
+ "windows_i686_msvc 0.30.0",
+ "windows_x86_64_gnu 0.30.0",
+ "windows_x86_64_msvc 0.30.0",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc 0.48.0",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -814,10 +816,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29277a4435d642f775f63c7d1faeb927adba532886ce0287bd985bffb16b6bca"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1145e1989da93956c68d1864f32fb97c8f561a8f89a5125f6a2b7ea75524e4b8"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -826,16 +840,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4a09e3a0d4753b73019db171c1339cd4362c8c44baf1bcea336235e955954a6"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ca64fcb0220d58db4c119e050e7af03c69e6f4f415ef69ec1773d9aab422d5a"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08cabc9f0066848fef4bc6a1c1668e6efce38b661d2aeec75d18d8617eebb5f1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "yansi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ lazy_static = "1.2.0"
 regex = "1.5.6"
 env_logger = "0.5.12"
 log = "0.4"
-inkwell =  { version = "0.1.0-beta.4", features = ["llvm13-0"] }
+inkwell =  { version = "0.2", features = ["llvm15-0"] }
 either = "1.5"
 serde = "*"
 serde_derive = '*'

--- a/build.rs
+++ b/build.rs
@@ -88,6 +88,15 @@ fn write_header(output_file: &mut File) {
 
             let expected_ret = expected_ret.parse::<i64>().unwrap();
 
+            let (ret_code, stdout) = super::helpers::test_utils::run(path, input.to_string(), config.clone());
+
+            assert_eq!(expected_ret, ret_code);
+            assert_eq!(expected_output, stdout);
+
+            // Test again with optimization disabled
+
+            config.no_optimize = true;
+            
             let (ret_code, stdout) = super::helpers::test_utils::run(path, input.to_string(), config);
 
             assert_eq!(expected_ret, ret_code);

--- a/src/lib/codegen/codegen_context.rs
+++ b/src/lib/codegen/codegen_context.rs
@@ -12,7 +12,7 @@ use inkwell::{
     types::{BasicType, BasicTypeEnum, FunctionType},
     values::{BasicValue, BasicValueEnum, FunctionValue},
     AddressSpace, FloatPredicate, IntPredicate,
-    OptimizationLevel::Aggressive,
+    OptimizationLevel::{self, Aggressive},
 };
 
 use crate::{
@@ -32,6 +32,15 @@ pub struct CodegenContext<'a> {
 impl<'a> CodegenContext<'a> {
     pub fn new(context: &'a Context, hir: &'a Root) -> Self {
         let module = context.create_module("mod");
+        let config = InitializationConfig::default();
+
+        Target::initialize_native(&config).unwrap();
+
+        let engine = module.create_execution_engine().unwrap();
+
+        let target = engine.get_target_data();
+        let layout = target.get_data_layout();
+        module.set_data_layout(&layout);
 
         Self {
             context,
@@ -43,10 +52,6 @@ impl<'a> CodegenContext<'a> {
     }
 
     pub fn optimize(&mut self) {
-        let config = InitializationConfig::default();
-
-        Target::initialize_native(&config).unwrap();
-
         let pass_manager_builder = PassManagerBuilder::create();
 
         pass_manager_builder.set_optimization_level(Aggressive);

--- a/src/lib/codegen/codegen_context.rs
+++ b/src/lib/codegen/codegen_context.rs
@@ -878,11 +878,15 @@ impl<'a> CodegenContext<'a> {
                 global_str.as_basic_value_enum()
             }
             LiteralKind::Array(arr) => {
+                let hir_type = self.hir.node_types.get(&lit.hir_id).unwrap();
                 let arr_type = self
-                    .lower_type(self.hir.node_types.get(&lit.hir_id).unwrap(), builder)
+                    .lower_type(hir_type, builder)
                     .unwrap()
                     .into_pointer_type()
                     .array_type(arr.values.len() as u32);
+
+                // hir_type.as_primitive_type().try_as_array().unwrap()
+                let real_arr_type = self.lower_type_real(hir_type, builder).unwrap();
 
                 let ptr = builder.build_alloca(arr_type, "array");
 
@@ -896,7 +900,8 @@ impl<'a> CodegenContext<'a> {
 
                     let inner_ptr = unsafe {
                         builder.build_gep(
-                            ptr.get_type(),
+                            // ptr.get_type(),
+                            real_arr_type,
                             ptr,
                             &[const_0, const_i],
                             format!("elem_{}", i).as_str(),

--- a/src/lib/codegen/codegen_context.rs
+++ b/src/lib/codegen/codegen_context.rs
@@ -1,4 +1,4 @@
-use std::convert::{TryFrom, TryInto};
+use std::convert::TryInto;
 
 use itertools::Itertools;
 
@@ -9,8 +9,8 @@ use inkwell::{
     module::Module,
     passes::{PassManager, PassManagerBuilder},
     targets::{InitializationConfig, Target},
-    types::{AnyTypeEnum, BasicType, BasicTypeEnum, FunctionType},
-    values::{AnyValueEnum, BasicValue, BasicValueEnum, CallSiteValue, FunctionValue},
+    types::{BasicType, BasicTypeEnum, FunctionType},
+    values::{BasicValue, BasicValueEnum, FunctionValue},
     AddressSpace, FloatPredicate, IntPredicate,
     OptimizationLevel::Aggressive,
 };
@@ -834,15 +834,6 @@ impl<'a> CodegenContext<'a> {
     ) -> Result<BasicValueEnum<'a>, ()> {
         let ptr = self.lower_indice_ptr(indice, builder)?.into_pointer_value();
 
-        let op_t = self.hir.node_types.get(&indice.op.get_hir_id()).unwrap();
-        let op_t = match op_t {
-            Type::Primitive(PrimitiveType::Array(t, _)) => t.as_ref().clone(),
-            Type::Primitive(PrimitiveType::String) => Type::int8(),
-            _ => panic!("indice op is not an array or string"),
-        };
-
-        let op_t = self.lower_type(&op_t, builder).unwrap();
-
         let t = self.hir.node_types.get(&indice.get_hir_id()).unwrap();
         let real_t = self.lower_type_real(t, builder).unwrap();
         let real_t = match real_t {
@@ -880,7 +871,7 @@ impl<'a> CodegenContext<'a> {
 
         let name = format!("{}.{}", dot.op.as_identifier().name, dot.value.name);
 
-        let ptr = unsafe { builder.build_struct_gep(t, op, indice as u32, name.as_str())? };
+        let ptr = builder.build_struct_gep(t, op, indice as u32, name.as_str())?;
 
         Ok(ptr.as_basic_value_enum())
     }

--- a/src/lib/codegen/codegen_context.rs
+++ b/src/lib/codegen/codegen_context.rs
@@ -55,7 +55,7 @@ impl<'a> CodegenContext<'a> {
 
         pass_manager.add_promote_memory_to_register_pass();
         // pass_manager.add_demote_memory_to_register_pass();
-        // disabled until llvm15
+        // disabled since llvm15
         // pass_manager.add_argument_promotion_pass();
         pass_manager.add_always_inliner_pass();
         pass_manager.add_gvn_pass();
@@ -87,7 +87,7 @@ impl<'a> CodegenContext<'a> {
         pass_manager.add_licm_pass();
         pass_manager.add_ind_var_simplify_pass();
         pass_manager.add_loop_vectorize_pass();
-        // disabled until llvm15
+        // disabled since llvm15
         // pass_manager.add_loop_unswitch_pass();
         pass_manager.add_loop_idiom_pass();
         pass_manager.add_loop_rotate_pass();

--- a/src/lib/codegen/mod.rs
+++ b/src/lib/codegen/mod.rs
@@ -11,10 +11,11 @@ pub fn generate(config: &Config, hir: Root) -> Result<(), Diagnostic> {
 
     let mut codegen_ctx = CodegenContext::new(&context, &hir);
 
-    if codegen_ctx.lower_hir(&hir, &builder).is_err() {
+    if let Err(e) = codegen_ctx.lower_hir(&hir, &builder) {
         // FIXME: have a movable `Diagnostics`
         // codegen_ctx.parsing_ctx.return_if_error()?;
-        panic!("GEN ERROR");
+        codegen_ctx.module.print_to_stderr();
+        panic!("GEN ERROR {:#?}", e);
     }
 
     match codegen_ctx.module.verify() {

--- a/src/lib/codegen/mod.rs
+++ b/src/lib/codegen/mod.rs
@@ -18,6 +18,8 @@ pub fn generate(config: &Config, hir: Root) -> Result<(), Diagnostic> {
         panic!("GEN ERROR {:#?}", e);
     }
 
+    // codegen_ctx.module.print_to_stderr();
+
     match codegen_ctx.module.verify() {
         Ok(_) => (),
         Err(e) => {

--- a/src/lib/codegen/mod.rs
+++ b/src/lib/codegen/mod.rs
@@ -33,6 +33,9 @@ pub fn generate(config: &Config, hir: Root) -> Result<(), Diagnostic> {
 
     if !config.no_optimize {
         codegen_ctx.optimize();
+        // optimize further
+        // FIXME: find a way to organize the pass-manager better to avoid the double pass
+        codegen_ctx.optimize();
     }
 
     if config.show_ir {

--- a/src/lib/hir/tree.rs
+++ b/src/lib/hir/tree.rs
@@ -547,7 +547,6 @@ impl Expression {
         } else if let ExpressionKind::FunctionCall(f) = &*self.kind {
             f.op.as_identifier()
         } else {
-            println!("{:#?}", self);
             panic!("Not an identifier");
         }
     }

--- a/src/lib/hir/tree.rs
+++ b/src/lib/hir/tree.rs
@@ -544,7 +544,10 @@ impl Expression {
             i.last_segment()
         } else if let ExpressionKind::Dot(d) = &*self.kind {
             d.value.clone()
+        } else if let ExpressionKind::FunctionCall(f) = &*self.kind {
+            f.op.as_identifier()
         } else {
+            println!("{:#?}", self);
             panic!("Not an identifier");
         }
     }

--- a/src/lib/parser/mod.rs
+++ b/src/lib/parser/mod.rs
@@ -1208,8 +1208,7 @@ pub fn parse_bool(input: Parser) -> Res<Parser, Literal> {
 pub fn parse_float(input: Parser) -> Res<Parser, Literal> {
     let (input, is_neg) = opt(char('-'))(input)?;
 
-    let (input, float_parsed) =
-        recognize(tuple((parse_number, char('.'), opt(parse_number))))(input)?;
+    let (input, float_parsed) = recognize(tuple((parse_number, char('.'), parse_number)))(input)?;
 
     let mut num: f64 = float_parsed
         .parse()

--- a/src/lib/parser/mod.rs
+++ b/src/lib/parser/mod.rs
@@ -982,7 +982,7 @@ pub fn parse_indice(input: Parser) -> Res<Parser, Box<Expression>> {
         tuple((
             terminated(tag("["), space0),
             terminated(parse_expression, space0),
-            terminated(tag("]"), space0),
+            preceded(space0, tag("]")),
         )),
         |(_, index, _)| Box::new(index),
     )(input)
@@ -1185,7 +1185,7 @@ pub fn parse_array(input: Parser) -> Res<Parser, Literal> {
                 tuple((space0, terminated(tag(","), space0), space0)),
                 parse_expression,
             ),
-            terminated(tag("]"), space0),
+            preceded(space0, tag("]")),
         )),
         |(node_id, _, elements, _)| {
             Literal::new_array(Array::new(elements.into_iter().collect()), node_id)

--- a/src/lib/parser/tests.rs
+++ b/src/lib/parser/tests.rs
@@ -87,15 +87,6 @@ mod parse_float {
     }
 
     #[test]
-    fn valid_no_last_part() {
-        let input = Parser::new_extra("42.", ParserCtx::new(PathBuf::new(), Config::default()));
-
-        let (_rest, parsed) = parse_float(input).finish().unwrap();
-
-        assert!(matches!(parsed.kind, LiteralKind::Float(f) if f == 42.0));
-    }
-
-    #[test]
     fn invalid() {
         let input = Parser::new_extra("a42.", ParserCtx::new(PathBuf::new(), Config::default()));
 

--- a/src/lib/testcases/basic/spaced_dot/main.rk
+++ b/src/lib/testcases/basic/spaced_dot/main.rk
@@ -1,9 +1,11 @@
 struct Toto
   lol: Int64
+  arr: [Int64]
 
 impl Toto
   new: x -> Toto
     lol: x
+    arr: [999]
   @me: -> @
   @get: a -> @lol
 

--- a/src/lib/testcases/basic/spaced_dot/main.rk
+++ b/src/lib/testcases/basic/spaced_dot/main.rk
@@ -1,11 +1,9 @@
 struct Toto
   lol: Int64
-  arr: [Int64]
 
 impl Toto
   new: x -> Toto
     lol: x
-    arr: [999]
   new_arr: arr -> Toto
     lol: 42
     arr: arr
@@ -18,6 +16,7 @@ main: ->
     .me!
     .me!
     .get 2
-  Toto::new_arr [1, 2, 3] .me!.me!.get 2
-  Toto::new_arr [1, 2, 3]
-    .me!.me!.get 2
+  #Toto::new_arr [1, 2, 3] .me!.me!.get 2
+  #Toto::new_arr [1, 2, 3]
+  #  .me!.me!.get 2
+

--- a/src/lib/testcases/basic/spaced_dot/main.rk
+++ b/src/lib/testcases/basic/spaced_dot/main.rk
@@ -6,6 +6,9 @@ impl Toto
   new: x -> Toto
     lol: x
     arr: [999]
+  new_arr: arr -> Toto
+    lol: 42
+    arr: arr
   @me: -> @
   @get: a -> @lol
 
@@ -15,3 +18,6 @@ main: ->
     .me!
     .me!
     .get 2
+  Toto::new_arr [1, 2, 3] .me!.me!.get 2
+  Toto::new_arr [1, 2, 3]
+    .me!.me!.get 2

--- a/src/lib/testcases/basic/spaced_dot/main.rk
+++ b/src/lib/testcases/basic/spaced_dot/main.rk
@@ -1,9 +1,11 @@
 struct Toto
   lol: Int64
+  arr: [Int64]
 
 impl Toto
   new: x -> Toto
     lol: x
+    arr: [999]
   new_arr: arr -> Toto
     lol: 42
     arr: arr
@@ -16,7 +18,7 @@ main: ->
     .me!
     .me!
     .get 2
-  #Toto::new_arr [1, 2, 3] .me!.me!.get 2
-  #Toto::new_arr [1, 2, 3]
-  #  .me!.me!.get 2
+  Toto::new_arr [1, 2, 3] .me!.me!.get 2
+  Toto::new_arr [1, 2, 3]
+    .me!.me!.get 2
 

--- a/src/lib/tests.rs
+++ b/src/lib/tests.rs
@@ -15,256 +15,12 @@ use std::path::PathBuf;
             assert_eq!(expected_output, stdout);
         }
         #[test]
-fn testcases_mods_basic_mod_main() {
-    run("testcases/mods/basic_mod/main.rk", include_str!("testcases/mods/basic_mod/main.rk"), include_str!("testcases/mods/basic_mod/main.rk.out"), include_str!("testcases/mods/basic_mod/main.rk.stdout"));
-}
-#[test]
-fn testcases_mods_func_arg_resolution_main() {
-    run("testcases/mods/func_arg_resolution/main.rk", include_str!("testcases/mods/func_arg_resolution/main.rk"), include_str!("testcases/mods/func_arg_resolution/main.rk.out"), include_str!("testcases/mods/func_arg_resolution/main.rk.stdout"));
-}
-#[test]
-fn testcases_mods_unused_impl_fn_main() {
-    run("testcases/mods/unused_impl_fn/main.rk", include_str!("testcases/mods/unused_impl_fn/main.rk"), include_str!("testcases/mods/unused_impl_fn/main.rk.out"), include_str!("testcases/mods/unused_impl_fn/main.rk.stdout"));
-}
-#[test]
-fn testcases_mods_unused_fn_main() {
-    run("testcases/mods/unused_fn/main.rk", include_str!("testcases/mods/unused_fn/main.rk"), include_str!("testcases/mods/unused_fn/main.rk.out"), include_str!("testcases/mods/unused_fn/main.rk.stdout"));
-}
-#[test]
-fn testcases_mods_full_fact_main() {
-    run("testcases/mods/full_fact/main.rk", include_str!("testcases/mods/full_fact/main.rk"), include_str!("testcases/mods/full_fact/main.rk.out"), include_str!("testcases/mods/full_fact/main.rk.stdout"));
-}
-#[test]
-fn testcases_mods_nested_trait_resolution_main() {
-    run("testcases/mods/nested_trait_resolution/main.rk", include_str!("testcases/mods/nested_trait_resolution/main.rk"), include_str!("testcases/mods/nested_trait_resolution/main.rk.out"), include_str!("testcases/mods/nested_trait_resolution/main.rk.stdout"));
-}
-#[test]
-fn testcases_mods_struct_new_main() {
-    run("testcases/mods/struct_new/main.rk", include_str!("testcases/mods/struct_new/main.rk"), include_str!("testcases/mods/struct_new/main.rk.out"), include_str!("testcases/mods/struct_new/main.rk.stdout"));
-}
-#[test]
-fn testcases_fails_basic_fn_bad_arg_nb2_main() {
-    run("testcases/fails/basic/fn_bad_arg_nb2/main.rk", include_str!("testcases/fails/basic/fn_bad_arg_nb2/main.rk"), include_str!("testcases/fails/basic/fn_bad_arg_nb2/main.rk.out"), include_str!("testcases/fails/basic/fn_bad_arg_nb2/main.rk.stdout"));
-}
-#[test]
-fn testcases_fails_basic_struct_bad_field_type_main() {
-    run("testcases/fails/basic/struct_bad_field_type/main.rk", include_str!("testcases/fails/basic/struct_bad_field_type/main.rk"), include_str!("testcases/fails/basic/struct_bad_field_type/main.rk.out"), include_str!("testcases/fails/basic/struct_bad_field_type/main.rk.stdout"));
-}
-#[test]
-fn testcases_fails_basic_fn_sig_main() {
-    run("testcases/fails/basic/fn_sig/main.rk", include_str!("testcases/fails/basic/fn_sig/main.rk"), include_str!("testcases/fails/basic/fn_sig/main.rk.out"), include_str!("testcases/fails/basic/fn_sig/main.rk.stdout"));
-}
-#[test]
-fn testcases_fails_basic_fn_bad_arg_nb_main() {
-    run("testcases/fails/basic/fn_bad_arg_nb/main.rk", include_str!("testcases/fails/basic/fn_bad_arg_nb/main.rk"), include_str!("testcases/fails/basic/fn_bad_arg_nb/main.rk.out"), include_str!("testcases/fails/basic/fn_bad_arg_nb/main.rk.stdout"));
-}
-#[test]
-fn testcases_fails_basic_fn_bad_arg_main() {
-    run("testcases/fails/basic/fn_bad_arg/main.rk", include_str!("testcases/fails/basic/fn_bad_arg/main.rk"), include_str!("testcases/fails/basic/fn_bad_arg/main.rk.out"), include_str!("testcases/fails/basic/fn_bad_arg/main.rk.stdout"));
-}
-#[test]
-fn testcases_fails_basic_fn_orpheline_sig_main() {
-    run("testcases/fails/basic/fn_orpheline_sig/main.rk", include_str!("testcases/fails/basic/fn_orpheline_sig/main.rk"), include_str!("testcases/fails/basic/fn_orpheline_sig/main.rk.out"), include_str!("testcases/fails/basic/fn_orpheline_sig/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_if_else_main() {
-    run("testcases/basic/if_else/main.rk", include_str!("testcases/basic/if_else/main.rk"), include_str!("testcases/basic/if_else/main.rk.out"), include_str!("testcases/basic/if_else/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_1_arg_fn_main() {
-    run("testcases/basic/1_arg_fn/main.rk", include_str!("testcases/basic/1_arg_fn/main.rk"), include_str!("testcases/basic/1_arg_fn/main.rk.out"), include_str!("testcases/basic/1_arg_fn/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_simple_char_main() {
-    run("testcases/basic/simple_char/main.rk", include_str!("testcases/basic/simple_char/main.rk"), include_str!("testcases/basic/simple_char/main.rk.out"), include_str!("testcases/basic/simple_char/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_indice_assign_main() {
-    run("testcases/basic/indice_assign/main.rk", include_str!("testcases/basic/indice_assign/main.rk"), include_str!("testcases/basic/indice_assign/main.rk.out"), include_str!("testcases/basic/indice_assign/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_extern_main() {
-    run("testcases/basic/extern/main.rk", include_str!("testcases/basic/extern/main.rk"), include_str!("testcases/basic/extern/main.rk.out"), include_str!("testcases/basic/extern/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_spaced_dot_main() {
-    run("testcases/basic/spaced_dot/main.rk", include_str!("testcases/basic/spaced_dot/main.rk"), include_str!("testcases/basic/spaced_dot/main.rk.out"), include_str!("testcases/basic/spaced_dot/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_monomorph_in_trait_main() {
-    run("testcases/basic/monomorph_in_trait/main.rk", include_str!("testcases/basic/monomorph_in_trait/main.rk"), include_str!("testcases/basic/monomorph_in_trait/main.rk.out"), include_str!("testcases/basic/monomorph_in_trait/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_fn_generic_sig_main() {
-    run("testcases/basic/fn_generic_sig/main.rk", include_str!("testcases/basic/fn_generic_sig/main.rk"), include_str!("testcases/basic/fn_generic_sig/main.rk.out"), include_str!("testcases/basic/fn_generic_sig/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_multiline_struct_const_main() {
-    run("testcases/basic/multiline_struct_const/main.rk", include_str!("testcases/basic/multiline_struct_const/main.rk"), include_str!("testcases/basic/multiline_struct_const/main.rk.out"), include_str!("testcases/basic/multiline_struct_const/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_nested_struct_dect_multiline_main() {
-    run("testcases/basic/nested_struct_dect_multiline/main.rk", include_str!("testcases/basic/nested_struct_dect_multiline/main.rk"), include_str!("testcases/basic/nested_struct_dect_multiline/main.rk.out"), include_str!("testcases/basic/nested_struct_dect_multiline/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_escaped_string_main() {
-    run("testcases/basic/escaped_string/main.rk", include_str!("testcases/basic/escaped_string/main.rk"), include_str!("testcases/basic/escaped_string/main.rk.out"), include_str!("testcases/basic/escaped_string/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_let_main() {
-    run("testcases/basic/let/main.rk", include_str!("testcases/basic/let/main.rk"), include_str!("testcases/basic/let/main.rk.out"), include_str!("testcases/basic/let/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_struct_array_field_main() {
-    run("testcases/basic/struct_array_field/main.rk", include_str!("testcases/basic/struct_array_field/main.rk"), include_str!("testcases/basic/struct_array_field/main.rk.out"), include_str!("testcases/basic/struct_array_field/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_trait_use_before_decl_main() {
-    run("testcases/basic/trait_use_before_decl/main.rk", include_str!("testcases/basic/trait_use_before_decl/main.rk"), include_str!("testcases/basic/trait_use_before_decl/main.rk.out"), include_str!("testcases/basic/trait_use_before_decl/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_while_main() {
-    run("testcases/basic/while/main.rk", include_str!("testcases/basic/while/main.rk"), include_str!("testcases/basic/while/main.rk.out"), include_str!("testcases/basic/while/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_self_returning_fn_main() {
-    run("testcases/basic/self_returning_fn/main.rk", include_str!("testcases/basic/self_returning_fn/main.rk"), include_str!("testcases/basic/self_returning_fn/main.rk.out"), include_str!("testcases/basic/self_returning_fn/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_simple_struct_main() {
-    run("testcases/basic/simple_struct/main.rk", include_str!("testcases/basic/simple_struct/main.rk"), include_str!("testcases/basic/simple_struct/main.rk.out"), include_str!("testcases/basic/simple_struct/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_early_return_main() {
-    run("testcases/basic/early_return/main.rk", include_str!("testcases/basic/early_return/main.rk"), include_str!("testcases/basic/early_return/main.rk.out"), include_str!("testcases/basic/early_return/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_bool_false_main() {
-    run("testcases/basic/bool_false/main.rk", include_str!("testcases/basic/bool_false/main.rk"), include_str!("testcases/basic/bool_false/main.rk.out"), include_str!("testcases/basic/bool_false/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_negative_floats_main() {
-    run("testcases/basic/negative_floats/main.rk", include_str!("testcases/basic/negative_floats/main.rk"), include_str!("testcases/basic/negative_floats/main.rk.out"), include_str!("testcases/basic/negative_floats/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_negative_floats_0_arg_fn_main() {
-    run("testcases/basic/negative_floats/0_arg_fn/main.rk", include_str!("testcases/basic/negative_floats/0_arg_fn/main.rk"), include_str!("testcases/basic/negative_floats/0_arg_fn/main.rk.out"), include_str!("testcases/basic/negative_floats/0_arg_fn/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_nested_array_main() {
-    run("testcases/basic/nested_array/main.rk", include_str!("testcases/basic/nested_array/main.rk"), include_str!("testcases/basic/nested_array/main.rk.out"), include_str!("testcases/basic/nested_array/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_reassign_return_main() {
-    run("testcases/basic/reassign_return/main.rk", include_str!("testcases/basic/reassign_return/main.rk"), include_str!("testcases/basic/reassign_return/main.rk.out"), include_str!("testcases/basic/reassign_return/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_impl_self_main() {
-    run("testcases/basic/impl_self/main.rk", include_str!("testcases/basic/impl_self/main.rk"), include_str!("testcases/basic/impl_self/main.rk.out"), include_str!("testcases/basic/impl_self/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_reassign_main() {
-    run("testcases/basic/reassign/main.rk", include_str!("testcases/basic/reassign/main.rk"), include_str!("testcases/basic/reassign/main.rk.out"), include_str!("testcases/basic/reassign/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_monomorph_main() {
-    run("testcases/basic/monomorph/main.rk", include_str!("testcases/basic/monomorph/main.rk"), include_str!("testcases/basic/monomorph/main.rk.out"), include_str!("testcases/basic/monomorph/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_op_func_main() {
-    run("testcases/basic/op_func/main.rk", include_str!("testcases/basic/op_func/main.rk"), include_str!("testcases/basic/op_func/main.rk.out"), include_str!("testcases/basic/op_func/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_struct_index_main() {
-    run("testcases/basic/struct_index/main.rk", include_str!("testcases/basic/struct_index/main.rk"), include_str!("testcases/basic/struct_index/main.rk.out"), include_str!("testcases/basic/struct_index/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_fn_sig_main() {
-    run("testcases/basic/fn_sig/main.rk", include_str!("testcases/basic/fn_sig/main.rk"), include_str!("testcases/basic/fn_sig/main.rk.out"), include_str!("testcases/basic/fn_sig/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_0_arg_fn_main() {
-    run("testcases/basic/0_arg_fn/main.rk", include_str!("testcases/basic/0_arg_fn/main.rk"), include_str!("testcases/basic/0_arg_fn/main.rk.out"), include_str!("testcases/basic/0_arg_fn/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_fn_arg_main() {
-    run("testcases/basic/fn_arg/main.rk", include_str!("testcases/basic/fn_arg/main.rk"), include_str!("testcases/basic/fn_arg/main.rk.out"), include_str!("testcases/basic/fn_arg/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_multi_style_struct_ctor_main() {
-    run("testcases/basic/multi_style_struct_ctor/main.rk", include_str!("testcases/basic/multi_style_struct_ctor/main.rk"), include_str!("testcases/basic/multi_style_struct_ctor/main.rk.out"), include_str!("testcases/basic/multi_style_struct_ctor/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_fn_arg_array_main() {
-    run("testcases/basic/fn_arg_array/main.rk", include_str!("testcases/basic/fn_arg_array/main.rk"), include_str!("testcases/basic/fn_arg_array/main.rk.out"), include_str!("testcases/basic/fn_arg_array/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_trait_monomorph_main() {
-    run("testcases/basic/trait_monomorph/main.rk", include_str!("testcases/basic/trait_monomorph/main.rk"), include_str!("testcases/basic/trait_monomorph/main.rk.out"), include_str!("testcases/basic/trait_monomorph/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_nested_struct_main() {
-    run("testcases/basic/nested_struct/main.rk", include_str!("testcases/basic/nested_struct/main.rk"), include_str!("testcases/basic/nested_struct/main.rk.out"), include_str!("testcases/basic/nested_struct/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_reassign_self_main() {
-    run("testcases/basic/reassign_self/main.rk", include_str!("testcases/basic/reassign_self/main.rk"), include_str!("testcases/basic/reassign_self/main.rk.out"), include_str!("testcases/basic/reassign_self/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_operator_precedence_main() {
-    run("testcases/basic/operator_precedence/main.rk", include_str!("testcases/basic/operator_precedence/main.rk"), include_str!("testcases/basic/operator_precedence/main.rk.out"), include_str!("testcases/basic/operator_precedence/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_main_main() {
-    run("testcases/basic/main/main.rk", include_str!("testcases/basic/main/main.rk"), include_str!("testcases/basic/main/main.rk.out"), include_str!("testcases/basic/main/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_bool_true_main() {
-    run("testcases/basic/bool_true/main.rk", include_str!("testcases/basic/bool_true/main.rk"), include_str!("testcases/basic/bool_true/main.rk.out"), include_str!("testcases/basic/bool_true/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_array_main() {
-    run("testcases/basic/array/main.rk", include_str!("testcases/basic/array/main.rk"), include_str!("testcases/basic/array/main.rk.out"), include_str!("testcases/basic/array/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_2_arg_fn_main() {
-    run("testcases/basic/2_arg_fn/main.rk", include_str!("testcases/basic/2_arg_fn/main.rk"), include_str!("testcases/basic/2_arg_fn/main.rk.out"), include_str!("testcases/basic/2_arg_fn/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_negative_numbers_main() {
-    run("testcases/basic/negative_numbers/main.rk", include_str!("testcases/basic/negative_numbers/main.rk"), include_str!("testcases/basic/negative_numbers/main.rk.out"), include_str!("testcases/basic/negative_numbers/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_negative_numbers_0_arg_fn_main() {
-    run("testcases/basic/negative_numbers/0_arg_fn/main.rk", include_str!("testcases/basic/negative_numbers/0_arg_fn/main.rk"), include_str!("testcases/basic/negative_numbers/0_arg_fn/main.rk.out"), include_str!("testcases/basic/negative_numbers/0_arg_fn/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_dot_assign_main() {
-    run("testcases/basic/dot_assign/main.rk", include_str!("testcases/basic/dot_assign/main.rk"), include_str!("testcases/basic/dot_assign/main.rk.out"), include_str!("testcases/basic/dot_assign/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_struct_impl_main() {
-    run("testcases/basic/struct_impl/main.rk", include_str!("testcases/basic/struct_impl/main.rk"), include_str!("testcases/basic/struct_impl/main.rk.out"), include_str!("testcases/basic/struct_impl/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_recur_main() {
-    run("testcases/basic/recur/main.rk", include_str!("testcases/basic/recur/main.rk"), include_str!("testcases/basic/recur/main.rk.out"), include_str!("testcases/basic/recur/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_no_newline_end_main() {
-    run("testcases/basic/no_newline_end/main.rk", include_str!("testcases/basic/no_newline_end/main.rk"), include_str!("testcases/basic/no_newline_end/main.rk.out"), include_str!("testcases/basic/no_newline_end/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_string_index_main() {
-    run("testcases/basic/string_index/main.rk", include_str!("testcases/basic/string_index/main.rk"), include_str!("testcases/basic/string_index/main.rk.out"), include_str!("testcases/basic/string_index/main.rk.stdout"));
-}
-#[test]
 fn testcases_trait_multi_resolution_main() {
     run("testcases/trait/multi_resolution/main.rk", include_str!("testcases/trait/multi_resolution/main.rk"), include_str!("testcases/trait/multi_resolution/main.rk.out"), include_str!("testcases/trait/multi_resolution/main.rk.stdout"));
 }
 #[test]
-fn testcases_trait_default_method_main() {
-    run("testcases/trait/default_method/main.rk", include_str!("testcases/trait/default_method/main.rk"), include_str!("testcases/trait/default_method/main.rk.out"), include_str!("testcases/trait/default_method/main.rk.stdout"));
+fn testcases_trait_default_method_override_main() {
+    run("testcases/trait/default_method_override/main.rk", include_str!("testcases/trait/default_method_override/main.rk"), include_str!("testcases/trait/default_method_override/main.rk.out"), include_str!("testcases/trait/default_method_override/main.rk.stdout"));
 }
 #[test]
 fn testcases_trait_late_resolution_main() {
@@ -275,6 +31,250 @@ fn testcases_trait_nested_fn_sig_main() {
     run("testcases/trait/nested_fn_sig/main.rk", include_str!("testcases/trait/nested_fn_sig/main.rk"), include_str!("testcases/trait/nested_fn_sig/main.rk.out"), include_str!("testcases/trait/nested_fn_sig/main.rk.stdout"));
 }
 #[test]
-fn testcases_trait_default_method_override_main() {
-    run("testcases/trait/default_method_override/main.rk", include_str!("testcases/trait/default_method_override/main.rk"), include_str!("testcases/trait/default_method_override/main.rk.out"), include_str!("testcases/trait/default_method_override/main.rk.stdout"));
+fn testcases_trait_default_method_main() {
+    run("testcases/trait/default_method/main.rk", include_str!("testcases/trait/default_method/main.rk"), include_str!("testcases/trait/default_method/main.rk.out"), include_str!("testcases/trait/default_method/main.rk.stdout"));
+}
+#[test]
+fn testcases_mods_func_arg_resolution_main() {
+    run("testcases/mods/func_arg_resolution/main.rk", include_str!("testcases/mods/func_arg_resolution/main.rk"), include_str!("testcases/mods/func_arg_resolution/main.rk.out"), include_str!("testcases/mods/func_arg_resolution/main.rk.stdout"));
+}
+#[test]
+fn testcases_mods_unused_fn_main() {
+    run("testcases/mods/unused_fn/main.rk", include_str!("testcases/mods/unused_fn/main.rk"), include_str!("testcases/mods/unused_fn/main.rk.out"), include_str!("testcases/mods/unused_fn/main.rk.stdout"));
+}
+#[test]
+fn testcases_mods_full_fact_main() {
+    run("testcases/mods/full_fact/main.rk", include_str!("testcases/mods/full_fact/main.rk"), include_str!("testcases/mods/full_fact/main.rk.out"), include_str!("testcases/mods/full_fact/main.rk.stdout"));
+}
+#[test]
+fn testcases_mods_basic_mod_main() {
+    run("testcases/mods/basic_mod/main.rk", include_str!("testcases/mods/basic_mod/main.rk"), include_str!("testcases/mods/basic_mod/main.rk.out"), include_str!("testcases/mods/basic_mod/main.rk.stdout"));
+}
+#[test]
+fn testcases_mods_unused_impl_fn_main() {
+    run("testcases/mods/unused_impl_fn/main.rk", include_str!("testcases/mods/unused_impl_fn/main.rk"), include_str!("testcases/mods/unused_impl_fn/main.rk.out"), include_str!("testcases/mods/unused_impl_fn/main.rk.stdout"));
+}
+#[test]
+fn testcases_mods_struct_new_main() {
+    run("testcases/mods/struct_new/main.rk", include_str!("testcases/mods/struct_new/main.rk"), include_str!("testcases/mods/struct_new/main.rk.out"), include_str!("testcases/mods/struct_new/main.rk.stdout"));
+}
+#[test]
+fn testcases_mods_nested_trait_resolution_main() {
+    run("testcases/mods/nested_trait_resolution/main.rk", include_str!("testcases/mods/nested_trait_resolution/main.rk"), include_str!("testcases/mods/nested_trait_resolution/main.rk.out"), include_str!("testcases/mods/nested_trait_resolution/main.rk.stdout"));
+}
+#[test]
+fn testcases_fails_basic_fn_bad_arg_main() {
+    run("testcases/fails/basic/fn_bad_arg/main.rk", include_str!("testcases/fails/basic/fn_bad_arg/main.rk"), include_str!("testcases/fails/basic/fn_bad_arg/main.rk.out"), include_str!("testcases/fails/basic/fn_bad_arg/main.rk.stdout"));
+}
+#[test]
+fn testcases_fails_basic_struct_bad_field_type_main() {
+    run("testcases/fails/basic/struct_bad_field_type/main.rk", include_str!("testcases/fails/basic/struct_bad_field_type/main.rk"), include_str!("testcases/fails/basic/struct_bad_field_type/main.rk.out"), include_str!("testcases/fails/basic/struct_bad_field_type/main.rk.stdout"));
+}
+#[test]
+fn testcases_fails_basic_fn_bad_arg_nb2_main() {
+    run("testcases/fails/basic/fn_bad_arg_nb2/main.rk", include_str!("testcases/fails/basic/fn_bad_arg_nb2/main.rk"), include_str!("testcases/fails/basic/fn_bad_arg_nb2/main.rk.out"), include_str!("testcases/fails/basic/fn_bad_arg_nb2/main.rk.stdout"));
+}
+#[test]
+fn testcases_fails_basic_fn_orpheline_sig_main() {
+    run("testcases/fails/basic/fn_orpheline_sig/main.rk", include_str!("testcases/fails/basic/fn_orpheline_sig/main.rk"), include_str!("testcases/fails/basic/fn_orpheline_sig/main.rk.out"), include_str!("testcases/fails/basic/fn_orpheline_sig/main.rk.stdout"));
+}
+#[test]
+fn testcases_fails_basic_fn_bad_arg_nb_main() {
+    run("testcases/fails/basic/fn_bad_arg_nb/main.rk", include_str!("testcases/fails/basic/fn_bad_arg_nb/main.rk"), include_str!("testcases/fails/basic/fn_bad_arg_nb/main.rk.out"), include_str!("testcases/fails/basic/fn_bad_arg_nb/main.rk.stdout"));
+}
+#[test]
+fn testcases_fails_basic_fn_sig_main() {
+    run("testcases/fails/basic/fn_sig/main.rk", include_str!("testcases/fails/basic/fn_sig/main.rk"), include_str!("testcases/fails/basic/fn_sig/main.rk.out"), include_str!("testcases/fails/basic/fn_sig/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_1_arg_fn_main() {
+    run("testcases/basic/1_arg_fn/main.rk", include_str!("testcases/basic/1_arg_fn/main.rk"), include_str!("testcases/basic/1_arg_fn/main.rk.out"), include_str!("testcases/basic/1_arg_fn/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_trait_monomorph_main() {
+    run("testcases/basic/trait_monomorph/main.rk", include_str!("testcases/basic/trait_monomorph/main.rk"), include_str!("testcases/basic/trait_monomorph/main.rk.out"), include_str!("testcases/basic/trait_monomorph/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_string_index_main() {
+    run("testcases/basic/string_index/main.rk", include_str!("testcases/basic/string_index/main.rk"), include_str!("testcases/basic/string_index/main.rk.out"), include_str!("testcases/basic/string_index/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_extern_main() {
+    run("testcases/basic/extern/main.rk", include_str!("testcases/basic/extern/main.rk"), include_str!("testcases/basic/extern/main.rk.out"), include_str!("testcases/basic/extern/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_trait_use_before_decl_main() {
+    run("testcases/basic/trait_use_before_decl/main.rk", include_str!("testcases/basic/trait_use_before_decl/main.rk"), include_str!("testcases/basic/trait_use_before_decl/main.rk.out"), include_str!("testcases/basic/trait_use_before_decl/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_spaced_dot_main() {
+    run("testcases/basic/spaced_dot/main.rk", include_str!("testcases/basic/spaced_dot/main.rk"), include_str!("testcases/basic/spaced_dot/main.rk.out"), include_str!("testcases/basic/spaced_dot/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_monomorph_main() {
+    run("testcases/basic/monomorph/main.rk", include_str!("testcases/basic/monomorph/main.rk"), include_str!("testcases/basic/monomorph/main.rk.out"), include_str!("testcases/basic/monomorph/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_main_main() {
+    run("testcases/basic/main/main.rk", include_str!("testcases/basic/main/main.rk"), include_str!("testcases/basic/main/main.rk.out"), include_str!("testcases/basic/main/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_fn_generic_sig_main() {
+    run("testcases/basic/fn_generic_sig/main.rk", include_str!("testcases/basic/fn_generic_sig/main.rk"), include_str!("testcases/basic/fn_generic_sig/main.rk.out"), include_str!("testcases/basic/fn_generic_sig/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_while_main() {
+    run("testcases/basic/while/main.rk", include_str!("testcases/basic/while/main.rk"), include_str!("testcases/basic/while/main.rk.out"), include_str!("testcases/basic/while/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_bool_false_main() {
+    run("testcases/basic/bool_false/main.rk", include_str!("testcases/basic/bool_false/main.rk"), include_str!("testcases/basic/bool_false/main.rk.out"), include_str!("testcases/basic/bool_false/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_let_main() {
+    run("testcases/basic/let/main.rk", include_str!("testcases/basic/let/main.rk"), include_str!("testcases/basic/let/main.rk.out"), include_str!("testcases/basic/let/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_bool_true_main() {
+    run("testcases/basic/bool_true/main.rk", include_str!("testcases/basic/bool_true/main.rk"), include_str!("testcases/basic/bool_true/main.rk.out"), include_str!("testcases/basic/bool_true/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_nested_array_main() {
+    run("testcases/basic/nested_array/main.rk", include_str!("testcases/basic/nested_array/main.rk"), include_str!("testcases/basic/nested_array/main.rk.out"), include_str!("testcases/basic/nested_array/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_no_newline_end_main() {
+    run("testcases/basic/no_newline_end/main.rk", include_str!("testcases/basic/no_newline_end/main.rk"), include_str!("testcases/basic/no_newline_end/main.rk.out"), include_str!("testcases/basic/no_newline_end/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_fn_arg_main() {
+    run("testcases/basic/fn_arg/main.rk", include_str!("testcases/basic/fn_arg/main.rk"), include_str!("testcases/basic/fn_arg/main.rk.out"), include_str!("testcases/basic/fn_arg/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_reassign_return_main() {
+    run("testcases/basic/reassign_return/main.rk", include_str!("testcases/basic/reassign_return/main.rk"), include_str!("testcases/basic/reassign_return/main.rk.out"), include_str!("testcases/basic/reassign_return/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_fn_arg_array_main() {
+    run("testcases/basic/fn_arg_array/main.rk", include_str!("testcases/basic/fn_arg_array/main.rk"), include_str!("testcases/basic/fn_arg_array/main.rk.out"), include_str!("testcases/basic/fn_arg_array/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_multi_style_struct_ctor_main() {
+    run("testcases/basic/multi_style_struct_ctor/main.rk", include_str!("testcases/basic/multi_style_struct_ctor/main.rk"), include_str!("testcases/basic/multi_style_struct_ctor/main.rk.out"), include_str!("testcases/basic/multi_style_struct_ctor/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_escaped_string_main() {
+    run("testcases/basic/escaped_string/main.rk", include_str!("testcases/basic/escaped_string/main.rk"), include_str!("testcases/basic/escaped_string/main.rk.out"), include_str!("testcases/basic/escaped_string/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_early_return_main() {
+    run("testcases/basic/early_return/main.rk", include_str!("testcases/basic/early_return/main.rk"), include_str!("testcases/basic/early_return/main.rk.out"), include_str!("testcases/basic/early_return/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_nested_struct_dect_multiline_main() {
+    run("testcases/basic/nested_struct_dect_multiline/main.rk", include_str!("testcases/basic/nested_struct_dect_multiline/main.rk"), include_str!("testcases/basic/nested_struct_dect_multiline/main.rk.out"), include_str!("testcases/basic/nested_struct_dect_multiline/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_impl_self_main() {
+    run("testcases/basic/impl_self/main.rk", include_str!("testcases/basic/impl_self/main.rk"), include_str!("testcases/basic/impl_self/main.rk.out"), include_str!("testcases/basic/impl_self/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_operator_precedence_main() {
+    run("testcases/basic/operator_precedence/main.rk", include_str!("testcases/basic/operator_precedence/main.rk"), include_str!("testcases/basic/operator_precedence/main.rk.out"), include_str!("testcases/basic/operator_precedence/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_reassign_main() {
+    run("testcases/basic/reassign/main.rk", include_str!("testcases/basic/reassign/main.rk"), include_str!("testcases/basic/reassign/main.rk.out"), include_str!("testcases/basic/reassign/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_simple_struct_main() {
+    run("testcases/basic/simple_struct/main.rk", include_str!("testcases/basic/simple_struct/main.rk"), include_str!("testcases/basic/simple_struct/main.rk.out"), include_str!("testcases/basic/simple_struct/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_struct_array_field_main() {
+    run("testcases/basic/struct_array_field/main.rk", include_str!("testcases/basic/struct_array_field/main.rk"), include_str!("testcases/basic/struct_array_field/main.rk.out"), include_str!("testcases/basic/struct_array_field/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_struct_impl_main() {
+    run("testcases/basic/struct_impl/main.rk", include_str!("testcases/basic/struct_impl/main.rk"), include_str!("testcases/basic/struct_impl/main.rk.out"), include_str!("testcases/basic/struct_impl/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_nested_struct_main() {
+    run("testcases/basic/nested_struct/main.rk", include_str!("testcases/basic/nested_struct/main.rk"), include_str!("testcases/basic/nested_struct/main.rk.out"), include_str!("testcases/basic/nested_struct/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_indice_assign_main() {
+    run("testcases/basic/indice_assign/main.rk", include_str!("testcases/basic/indice_assign/main.rk"), include_str!("testcases/basic/indice_assign/main.rk.out"), include_str!("testcases/basic/indice_assign/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_fn_sig_main() {
+    run("testcases/basic/fn_sig/main.rk", include_str!("testcases/basic/fn_sig/main.rk"), include_str!("testcases/basic/fn_sig/main.rk.out"), include_str!("testcases/basic/fn_sig/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_recur_main() {
+    run("testcases/basic/recur/main.rk", include_str!("testcases/basic/recur/main.rk"), include_str!("testcases/basic/recur/main.rk.out"), include_str!("testcases/basic/recur/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_2_arg_fn_main() {
+    run("testcases/basic/2_arg_fn/main.rk", include_str!("testcases/basic/2_arg_fn/main.rk"), include_str!("testcases/basic/2_arg_fn/main.rk.out"), include_str!("testcases/basic/2_arg_fn/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_monomorph_in_trait_main() {
+    run("testcases/basic/monomorph_in_trait/main.rk", include_str!("testcases/basic/monomorph_in_trait/main.rk"), include_str!("testcases/basic/monomorph_in_trait/main.rk.out"), include_str!("testcases/basic/monomorph_in_trait/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_reassign_self_main() {
+    run("testcases/basic/reassign_self/main.rk", include_str!("testcases/basic/reassign_self/main.rk"), include_str!("testcases/basic/reassign_self/main.rk.out"), include_str!("testcases/basic/reassign_self/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_array_main() {
+    run("testcases/basic/array/main.rk", include_str!("testcases/basic/array/main.rk"), include_str!("testcases/basic/array/main.rk.out"), include_str!("testcases/basic/array/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_struct_index_main() {
+    run("testcases/basic/struct_index/main.rk", include_str!("testcases/basic/struct_index/main.rk"), include_str!("testcases/basic/struct_index/main.rk.out"), include_str!("testcases/basic/struct_index/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_op_func_main() {
+    run("testcases/basic/op_func/main.rk", include_str!("testcases/basic/op_func/main.rk"), include_str!("testcases/basic/op_func/main.rk.out"), include_str!("testcases/basic/op_func/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_negative_numbers_main() {
+    run("testcases/basic/negative_numbers/main.rk", include_str!("testcases/basic/negative_numbers/main.rk"), include_str!("testcases/basic/negative_numbers/main.rk.out"), include_str!("testcases/basic/negative_numbers/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_negative_numbers_0_arg_fn_main() {
+    run("testcases/basic/negative_numbers/0_arg_fn/main.rk", include_str!("testcases/basic/negative_numbers/0_arg_fn/main.rk"), include_str!("testcases/basic/negative_numbers/0_arg_fn/main.rk.out"), include_str!("testcases/basic/negative_numbers/0_arg_fn/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_self_returning_fn_main() {
+    run("testcases/basic/self_returning_fn/main.rk", include_str!("testcases/basic/self_returning_fn/main.rk"), include_str!("testcases/basic/self_returning_fn/main.rk.out"), include_str!("testcases/basic/self_returning_fn/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_0_arg_fn_main() {
+    run("testcases/basic/0_arg_fn/main.rk", include_str!("testcases/basic/0_arg_fn/main.rk"), include_str!("testcases/basic/0_arg_fn/main.rk.out"), include_str!("testcases/basic/0_arg_fn/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_simple_char_main() {
+    run("testcases/basic/simple_char/main.rk", include_str!("testcases/basic/simple_char/main.rk"), include_str!("testcases/basic/simple_char/main.rk.out"), include_str!("testcases/basic/simple_char/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_if_else_main() {
+    run("testcases/basic/if_else/main.rk", include_str!("testcases/basic/if_else/main.rk"), include_str!("testcases/basic/if_else/main.rk.out"), include_str!("testcases/basic/if_else/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_multiline_struct_const_main() {
+    run("testcases/basic/multiline_struct_const/main.rk", include_str!("testcases/basic/multiline_struct_const/main.rk"), include_str!("testcases/basic/multiline_struct_const/main.rk.out"), include_str!("testcases/basic/multiline_struct_const/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_dot_assign_main() {
+    run("testcases/basic/dot_assign/main.rk", include_str!("testcases/basic/dot_assign/main.rk"), include_str!("testcases/basic/dot_assign/main.rk.out"), include_str!("testcases/basic/dot_assign/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_negative_floats_main() {
+    run("testcases/basic/negative_floats/main.rk", include_str!("testcases/basic/negative_floats/main.rk"), include_str!("testcases/basic/negative_floats/main.rk.out"), include_str!("testcases/basic/negative_floats/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_negative_floats_0_arg_fn_main() {
+    run("testcases/basic/negative_floats/0_arg_fn/main.rk", include_str!("testcases/basic/negative_floats/0_arg_fn/main.rk"), include_str!("testcases/basic/negative_floats/0_arg_fn/main.rk.out"), include_str!("testcases/basic/negative_floats/0_arg_fn/main.rk.stdout"));
 }

--- a/src/lib/tests.rs
+++ b/src/lib/tests.rs
@@ -9,6 +9,15 @@ use std::path::PathBuf;
 
             let expected_ret = expected_ret.parse::<i64>().unwrap();
 
+            let (ret_code, stdout) = super::helpers::test_utils::run(path, input.to_string(), config.clone());
+
+            assert_eq!(expected_ret, ret_code);
+            assert_eq!(expected_output, stdout);
+
+            // Test again with optimization disabled
+
+            config.no_optimize = true;
+            
             let (ret_code, stdout) = super::helpers::test_utils::run(path, input.to_string(), config);
 
             assert_eq!(expected_ret, ret_code);

--- a/src/lib/ty/primitive_type.rs
+++ b/src/lib/ty/primitive_type.rs
@@ -33,7 +33,7 @@ impl PrimitiveType {
             Self::Int64 => "Int64".to_string(),
             Self::Float64 => "Float64".to_string(),
             Self::String => "String".to_string(),
-            Self::Array(t, size) => format!("[{}, {}]", t.get_name(), size),
+            Self::Array(t, _size) => format!("[{}]", t.get_name()),
             Self::Char => "Char".to_string(),
         }
     }

--- a/src/lib/ty/primitive_type.rs
+++ b/src/lib/ty/primitive_type.rs
@@ -33,7 +33,7 @@ impl PrimitiveType {
             Self::Int64 => "Int64".to_string(),
             Self::Float64 => "Float64".to_string(),
             Self::String => "String".to_string(),
-            Self::Array(t, _size) => format!("[{}]", t.get_name()),
+            Self::Array(t, size) => format!("[{}, {}]", t.get_name(), size),
             Self::Char => "Char".to_string(),
         }
     }

--- a/src/lib/ty/type.rs
+++ b/src/lib/ty/type.rs
@@ -53,6 +53,10 @@ macro_rules! generate_primitive_checks {
 }
 
 impl Type {
+    pub fn int8() -> Self {
+        Self::Primitive(PrimitiveType::Int8)
+    }
+
     pub fn int64() -> Self {
         Self::Primitive(PrimitiveType::Int64)
     }

--- a/std/src/eq.rk
+++ b/std/src/eq.rk
@@ -12,37 +12,37 @@ trait Eq
   >  : @ => @ => Bool
 
 impl Eq Int64
-  ==: e, f -> ~IEq e f
-  <=: e, f -> ~Ile e f
-  >=: e, f -> ~Ige e f
-  < : e, f -> ~Ilt e f
-  > : e, f -> ~Igt e f
+  == : e, f -> ~IEq e f
+  <= : e, f -> ~Ile e f
+  >= : e, f -> ~Ige e f
+  <  : e, f -> ~Ilt e f
+  >  : e, f -> ~Igt e f
 
 impl Eq Float64
-  ==: g, h -> ~FEq g h
-  <=: g, h -> ~Fle g h
-  >=: g, h -> ~Fge g h
-  < : g, h -> ~Flt g h
-  > : g, h -> ~Fgt g h
+  == : g, h -> ~FEq g h
+  <= : g, h -> ~Fle g h
+  >= : g, h -> ~Fge g h
+  <  : g, h -> ~Flt g h
+  >  : g, h -> ~Fgt g h
 
 impl Eq Bool
-  ==: i, j -> ~BEq i j
-  <=: i, j -> ~BEq i j
-  >=: i, j -> ~BEq i j
-  < : i, j -> ~BEq i j
-  > : i, j -> ~BEq i j
+  == : i, j -> ~BEq i j
+  <= : i, j -> ~BEq i j
+  >= : i, j -> ~BEq i j
+  <  : i, j -> ~BEq i j
+  >  : i, j -> ~BEq i j
 
 impl Eq Char
-  ==: e, f -> ~IEq e f
-  <=: e, f -> ~Ile e f
-  >=: e, f -> ~Ige e f
-  < : e, f -> ~Ilt e f
-  > : e, f -> ~Igt e f
+  == : e, f -> ~IEq e f
+  <= : e, f -> ~Ile e f
+  >= : e, f -> ~Ige e f
+  <  : e, f -> ~Ilt e f
+  >  : e, f -> ~Igt e f
 
 use super::externs::strcmp
 
 impl Eq String
-  ==: k, l -> strcmp k, l == 0
+  == : k, l -> strcmp k, l == 0
 
 use Eq::(*)
 

--- a/std/src/print.rk
+++ b/std/src/print.rk
@@ -8,10 +8,12 @@ use super::num::(*)
 trait Print
   @print: ->
     puts @show!
+    # There is a bug that disallow self-returning function definition in traits (#174)
     @
   @putstr: ->
     printf "%s", @show!
     fflush 0
+    # There is a bug that disallow self-returning function definition in traits (#174)
     @
 
 # Here we would need generic impl

--- a/std/src/print.rk
+++ b/std/src/print.rk
@@ -6,10 +6,13 @@ use super::eq::(*)
 use super::num::(*)
 
 trait Print
-  @print: -> puts @show!
+  @print: ->
+    puts @show!
+    @
   @putstr: ->
     printf "%s", @show!
     fflush 0
+    @
 
 # Here we would need generic impl
 impl Print Bool
@@ -18,3 +21,4 @@ impl Print Float64
 impl Print String
 impl Print Char
 
+impl Print [Int64]


### PR DESCRIPTION
Some tests don't pass when disabling LLVM optimizations. 

Better to fix it before merging 

failures:
    tests::testcases_basic_self_returning_fn_main
    tests::testcases_basic_struct_array_field_main

