### PR TITLE
Alloca to Malloc for strucs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,14 +14,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    # - name: Install libpolly-15-dev
-    #   run: |
-    #     git clone --depth 1 https://github.com/llvm/llvm-project.git
-    #     cd llvm-project
-    #     mkdir build && cd build
-    #     cmake '-DLLVM_ENABLE_PROJECTS=polly' -DCMAKE_BUILD_TYPE=MinSizeRel ../llvm
-    #     cmake --build .
-
     - name: Apt Update
       run: |
         sudo apt update

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,13 +11,21 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
+    - name: Install libpolly-15-dev
+      run: |
+        git clone --depth 1 https://github.com/llvm/llvm-project.git
+        cd llvm-project
+        mkdir build && cd build
+        cmake '-DLLVM_ENABLE_PROJECTS=clang;polly' -DCMAKE_BUILD_TYPE=MinSizeRel ../llvm
+        cmake --build .
+
     - name: Apt Update
       run: |
         sudo apt update
-        sudo apt install llvm-13 clang
+        sudo apt install llvm-15 clang
 
     - name: Rust Cache
       uses: Swatinem/rust-cache@v1.3.0

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,18 +14,24 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Install libpolly-15-dev
-      run: |
-        git clone --depth 1 https://github.com/llvm/llvm-project.git
-        cd llvm-project
-        mkdir build && cd build
-        cmake '-DLLVM_ENABLE_PROJECTS=clang;polly' -DCMAKE_BUILD_TYPE=MinSizeRel ../llvm
-        cmake --build .
+    # - name: Install libpolly-15-dev
+    #   run: |
+    #     git clone --depth 1 https://github.com/llvm/llvm-project.git
+    #     cd llvm-project
+    #     mkdir build && cd build
+    #     cmake '-DLLVM_ENABLE_PROJECTS=polly' -DCMAKE_BUILD_TYPE=MinSizeRel ../llvm
+    #     cmake --build .
 
     - name: Apt Update
       run: |
         sudo apt update
-        sudo apt install llvm-15 clang
+        sudo apt remove llvm-15 clang
+        sudo apt install llvm-15 llvm-15-tools clang-15
+
+    - name: Link correct clang version
+      run: |
+        sudo mv /usr/bin/clang /usr/bin/clang-14
+        sudo ln /usr/bin/clang-15 /usr/bin/clang
 
     - name: Rust Cache
       uses: Swatinem/rust-cache@v1.3.0

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Feel free to discuss any new feature or change you may like in an issue! We welc
 
 ### From source
 
-You will need `llvm-13` and `clang-13` somewhere in your $PATH
+You will need `llvm-15` and `clang-15` somewhere in your $PATH
 
 #### With Cargo from Git (Recommanded)
 

--- a/src/lib/codegen/codegen_context.rs
+++ b/src/lib/codegen/codegen_context.rs
@@ -3,6 +3,7 @@ use std::convert::TryInto;
 use itertools::Itertools;
 
 use inkwell::{
+    attributes::{Attribute, AttributeLoc},
     basic_block::BasicBlock,
     builder::Builder,
     context::Context,
@@ -100,6 +101,8 @@ impl<'a> CodegenContext<'a> {
         pass_manager.add_loop_unroll_pass();
         pass_manager.add_loop_deletion_pass();
         pass_manager.add_cfg_simplification_pass();
+
+        pass_manager.add_dead_store_elimination_pass();
 
         pass_manager.add_verifier_pass();
 
@@ -302,6 +305,50 @@ impl<'a> CodegenContext<'a> {
             };
 
             let fn_value = self.module.add_function(&p.name.name, fn_type, None);
+
+            // special attribute for malloc
+            if p.name.name == "malloc" {
+                fn_value.add_attribute(
+                    AttributeLoc::Function,
+                    self.context
+                        .create_enum_attribute(Attribute::get_named_enum_kind_id("allockind"), 41),
+                );
+
+                fn_value.add_attribute(
+                    AttributeLoc::Function,
+                    self.context
+                        .create_string_attribute("alloc-family", "malloc"),
+                );
+
+                //allocsize
+                // FIXME: this is not working
+                /* fn_value.add_attribute(
+                    AttributeLoc::Function,
+                    self.context
+                        .create_enum_attribute(Attribute::get_named_enum_kind_id("allocsize"), 0),
+                ); */
+
+                fn_value.add_attribute(
+                    AttributeLoc::Return,
+                    self.context
+                        .create_enum_attribute(Attribute::get_named_enum_kind_id("noalias"), 0),
+                );
+            }
+
+            // special attribute for free
+            if p.name.name == "free" {
+                fn_value.add_attribute(
+                    AttributeLoc::Function,
+                    self.context
+                        .create_enum_attribute(Attribute::get_named_enum_kind_id("allockind"), 4),
+                );
+
+                fn_value.add_attribute(
+                    AttributeLoc::Function,
+                    self.context
+                        .create_string_attribute("alloc-family", "malloc"),
+                );
+            }
 
             self.scopes.add(
                 p.hir_id.clone(),
@@ -726,7 +773,18 @@ impl<'a> CodegenContext<'a> {
             })
             .collect::<Vec<_>>();
 
-        let ptr = builder.build_alloca(llvm_struct_t_real, "struct_ptr");
+        // We use malloc here to be able to return the struct
+        let malloc = self.module.get_function("malloc").unwrap();
+        let ptr = builder
+            .build_call(
+                malloc,
+                &[llvm_struct_t_real.size_of().unwrap().into()],
+                format!("malloc_{}", t.get_name()).as_str(),
+            )
+            .try_as_basic_value()
+            .left()
+            .unwrap()
+            .into_pointer_value();
 
         for (i, def) in defs.iter().enumerate() {
             let inner_ptr = builder

--- a/src/lib/codegen/codegen_context.rs
+++ b/src/lib/codegen/codegen_context.rs
@@ -13,13 +13,13 @@ use inkwell::{
     types::{BasicType, BasicTypeEnum, FunctionType},
     values::{BasicValue, BasicValueEnum, FunctionValue},
     AddressSpace, FloatPredicate, IntPredicate,
-    OptimizationLevel::{self, Aggressive},
+    OptimizationLevel::Aggressive,
 };
 
 use crate::{
     helpers::scopes::Scopes,
     hir::*,
-    ty::{FuncType, PrimitiveType, Type},
+    ty::{PrimitiveType, Type},
 };
 
 pub struct CodegenContext<'a> {

--- a/src/lib/codegen/mod.rs
+++ b/src/lib/codegen/mod.rs
@@ -3,11 +3,52 @@ mod codegen_context;
 use codegen_context::*;
 use inkwell::context::Context;
 
-use crate::{diagnostics::Diagnostic, hir::Root, Config};
+use crate::{
+    diagnostics::Diagnostic,
+    hir::{HirId, Identifier, Prototype, Root, TopLevel, TopLevelKind},
+    ty::{FuncType, PrimitiveType, Type},
+    Config,
+};
 
-pub fn generate(config: &Config, hir: Root) -> Result<(), Diagnostic> {
+pub fn add_builtins(hir: &mut Root) {
+    let mut builtins = Vec::new();
+
+    builtins.push(TopLevel {
+        kind: TopLevelKind::Extern(Prototype {
+            name: Identifier {
+                name: "malloc".to_string(),
+                hir_id: HirId(99996), // FIXME: what if this hir_id already exists ?
+            },
+            signature: FuncType {
+                arguments: vec![Type::Primitive(PrimitiveType::Int64)],
+                ret: Box::new(Type::Primitive(PrimitiveType::String)),
+            },
+            hir_id: HirId(99997), // FIXME: bis
+        }),
+    });
+
+    builtins.push(TopLevel {
+        kind: TopLevelKind::Extern(Prototype {
+            name: Identifier {
+                name: "free".to_string(),
+                hir_id: HirId(99998), // FIXME: what if this hir_id already exists ?
+            },
+            signature: FuncType {
+                arguments: vec![Type::Primitive(PrimitiveType::String)],
+                ret: Box::new(Type::Primitive(PrimitiveType::Int64)),
+            },
+            hir_id: HirId(99999), // FIXME: bis
+        }),
+    });
+
+    hir.top_levels.append(&mut builtins);
+}
+
+pub fn generate(config: &Config, mut hir: Root) -> Result<(), Diagnostic> {
     let context = Context::create();
     let builder = context.create_builder();
+
+    add_builtins(&mut hir);
 
     let mut codegen_ctx = CodegenContext::new(&context, &hir);
 

--- a/src/lib/codegen/mod.rs
+++ b/src/lib/codegen/mod.rs
@@ -17,13 +17,13 @@ pub fn add_builtins(hir: &mut Root) {
         kind: TopLevelKind::Extern(Prototype {
             name: Identifier {
                 name: "malloc".to_string(),
-                hir_id: HirId(99996), // FIXME: what if this hir_id already exists ?
+                hir_id: HirId(9999996), // FIXME: what if this hir_id already exists ?
             },
             signature: FuncType {
                 arguments: vec![Type::Primitive(PrimitiveType::Int64)],
                 ret: Box::new(Type::Primitive(PrimitiveType::String)),
             },
-            hir_id: HirId(99997), // FIXME: bis
+            hir_id: HirId(9999997), // FIXME: bis
         }),
     });
 
@@ -31,13 +31,13 @@ pub fn add_builtins(hir: &mut Root) {
         kind: TopLevelKind::Extern(Prototype {
             name: Identifier {
                 name: "free".to_string(),
-                hir_id: HirId(99998), // FIXME: what if this hir_id already exists ?
+                hir_id: HirId(9999998), // FIXME: what if this hir_id already exists ?
             },
             signature: FuncType {
                 arguments: vec![Type::Primitive(PrimitiveType::String)],
                 ret: Box::new(Type::Primitive(PrimitiveType::Int64)),
             },
-            hir_id: HirId(99999), // FIXME: bis
+            hir_id: HirId(9999999), // FIXME: bis
         }),
     });
 

--- a/src/lib/parser/mod.rs
+++ b/src/lib/parser/mod.rs
@@ -1274,7 +1274,7 @@ pub fn parse_type(input: Parser) -> Res<Parser, Type> {
         map(delimited(tag("["), parse_type, tag("]")), |t| {
             Type::Primitive(PrimitiveType::Array(
                 Box::new(t),
-                0, // FIXME
+                10, // FIXME
             ))
         }),
         map(

--- a/src/lib/parser/source_file.rs
+++ b/src/lib/parser/source_file.rs
@@ -42,14 +42,14 @@ impl SourceFile {
     }
 
     pub fn from_str(path: &str, content: &str) -> Result<Self, Diagnostic> {
-        let mut mod_path = PathBuf::from(path.clone());
+        let mut mod_path = PathBuf::from(path);
 
         mod_path.set_extension("");
 
         let content = Self::sanitize_content(&content);
 
         Ok(SourceFile {
-            file_path: PathBuf::from(path.clone()),
+            file_path: PathBuf::from(path),
             mod_path,
             content,
         })

--- a/src/lib/tests.rs
+++ b/src/lib/tests.rs
@@ -24,48 +24,48 @@ use std::path::PathBuf;
             assert_eq!(expected_output, stdout);
         }
         #[test]
-fn testcases_trait_multi_resolution_main() {
-    run("testcases/trait/multi_resolution/main.rk", include_str!("testcases/trait/multi_resolution/main.rk"), include_str!("testcases/trait/multi_resolution/main.rk.out"), include_str!("testcases/trait/multi_resolution/main.rk.stdout"));
-}
-#[test]
 fn testcases_trait_default_method_override_main() {
     run("testcases/trait/default_method_override/main.rk", include_str!("testcases/trait/default_method_override/main.rk"), include_str!("testcases/trait/default_method_override/main.rk.out"), include_str!("testcases/trait/default_method_override/main.rk.stdout"));
-}
-#[test]
-fn testcases_trait_late_resolution_main() {
-    run("testcases/trait/late_resolution/main.rk", include_str!("testcases/trait/late_resolution/main.rk"), include_str!("testcases/trait/late_resolution/main.rk.out"), include_str!("testcases/trait/late_resolution/main.rk.stdout"));
-}
-#[test]
-fn testcases_trait_nested_fn_sig_main() {
-    run("testcases/trait/nested_fn_sig/main.rk", include_str!("testcases/trait/nested_fn_sig/main.rk"), include_str!("testcases/trait/nested_fn_sig/main.rk.out"), include_str!("testcases/trait/nested_fn_sig/main.rk.stdout"));
 }
 #[test]
 fn testcases_trait_default_method_main() {
     run("testcases/trait/default_method/main.rk", include_str!("testcases/trait/default_method/main.rk"), include_str!("testcases/trait/default_method/main.rk.out"), include_str!("testcases/trait/default_method/main.rk.stdout"));
 }
 #[test]
+fn testcases_trait_nested_fn_sig_main() {
+    run("testcases/trait/nested_fn_sig/main.rk", include_str!("testcases/trait/nested_fn_sig/main.rk"), include_str!("testcases/trait/nested_fn_sig/main.rk.out"), include_str!("testcases/trait/nested_fn_sig/main.rk.stdout"));
+}
+#[test]
+fn testcases_trait_late_resolution_main() {
+    run("testcases/trait/late_resolution/main.rk", include_str!("testcases/trait/late_resolution/main.rk"), include_str!("testcases/trait/late_resolution/main.rk.out"), include_str!("testcases/trait/late_resolution/main.rk.stdout"));
+}
+#[test]
+fn testcases_trait_multi_resolution_main() {
+    run("testcases/trait/multi_resolution/main.rk", include_str!("testcases/trait/multi_resolution/main.rk"), include_str!("testcases/trait/multi_resolution/main.rk.out"), include_str!("testcases/trait/multi_resolution/main.rk.stdout"));
+}
+#[test]
 fn testcases_mods_func_arg_resolution_main() {
     run("testcases/mods/func_arg_resolution/main.rk", include_str!("testcases/mods/func_arg_resolution/main.rk"), include_str!("testcases/mods/func_arg_resolution/main.rk.out"), include_str!("testcases/mods/func_arg_resolution/main.rk.stdout"));
-}
-#[test]
-fn testcases_mods_unused_fn_main() {
-    run("testcases/mods/unused_fn/main.rk", include_str!("testcases/mods/unused_fn/main.rk"), include_str!("testcases/mods/unused_fn/main.rk.out"), include_str!("testcases/mods/unused_fn/main.rk.stdout"));
-}
-#[test]
-fn testcases_mods_full_fact_main() {
-    run("testcases/mods/full_fact/main.rk", include_str!("testcases/mods/full_fact/main.rk"), include_str!("testcases/mods/full_fact/main.rk.out"), include_str!("testcases/mods/full_fact/main.rk.stdout"));
-}
-#[test]
-fn testcases_mods_basic_mod_main() {
-    run("testcases/mods/basic_mod/main.rk", include_str!("testcases/mods/basic_mod/main.rk"), include_str!("testcases/mods/basic_mod/main.rk.out"), include_str!("testcases/mods/basic_mod/main.rk.stdout"));
 }
 #[test]
 fn testcases_mods_unused_impl_fn_main() {
     run("testcases/mods/unused_impl_fn/main.rk", include_str!("testcases/mods/unused_impl_fn/main.rk"), include_str!("testcases/mods/unused_impl_fn/main.rk.out"), include_str!("testcases/mods/unused_impl_fn/main.rk.stdout"));
 }
 #[test]
+fn testcases_mods_basic_mod_main() {
+    run("testcases/mods/basic_mod/main.rk", include_str!("testcases/mods/basic_mod/main.rk"), include_str!("testcases/mods/basic_mod/main.rk.out"), include_str!("testcases/mods/basic_mod/main.rk.stdout"));
+}
+#[test]
 fn testcases_mods_struct_new_main() {
     run("testcases/mods/struct_new/main.rk", include_str!("testcases/mods/struct_new/main.rk"), include_str!("testcases/mods/struct_new/main.rk.out"), include_str!("testcases/mods/struct_new/main.rk.stdout"));
+}
+#[test]
+fn testcases_mods_full_fact_main() {
+    run("testcases/mods/full_fact/main.rk", include_str!("testcases/mods/full_fact/main.rk"), include_str!("testcases/mods/full_fact/main.rk.out"), include_str!("testcases/mods/full_fact/main.rk.stdout"));
+}
+#[test]
+fn testcases_mods_unused_fn_main() {
+    run("testcases/mods/unused_fn/main.rk", include_str!("testcases/mods/unused_fn/main.rk"), include_str!("testcases/mods/unused_fn/main.rk.out"), include_str!("testcases/mods/unused_fn/main.rk.stdout"));
 }
 #[test]
 fn testcases_mods_nested_trait_resolution_main() {
@@ -74,10 +74,6 @@ fn testcases_mods_nested_trait_resolution_main() {
 #[test]
 fn testcases_fails_basic_fn_bad_arg_main() {
     run("testcases/fails/basic/fn_bad_arg/main.rk", include_str!("testcases/fails/basic/fn_bad_arg/main.rk"), include_str!("testcases/fails/basic/fn_bad_arg/main.rk.out"), include_str!("testcases/fails/basic/fn_bad_arg/main.rk.stdout"));
-}
-#[test]
-fn testcases_fails_basic_struct_bad_field_type_main() {
-    run("testcases/fails/basic/struct_bad_field_type/main.rk", include_str!("testcases/fails/basic/struct_bad_field_type/main.rk"), include_str!("testcases/fails/basic/struct_bad_field_type/main.rk.out"), include_str!("testcases/fails/basic/struct_bad_field_type/main.rk.stdout"));
 }
 #[test]
 fn testcases_fails_basic_fn_bad_arg_nb2_main() {
@@ -92,160 +88,32 @@ fn testcases_fails_basic_fn_bad_arg_nb_main() {
     run("testcases/fails/basic/fn_bad_arg_nb/main.rk", include_str!("testcases/fails/basic/fn_bad_arg_nb/main.rk"), include_str!("testcases/fails/basic/fn_bad_arg_nb/main.rk.out"), include_str!("testcases/fails/basic/fn_bad_arg_nb/main.rk.stdout"));
 }
 #[test]
+fn testcases_fails_basic_struct_bad_field_type_main() {
+    run("testcases/fails/basic/struct_bad_field_type/main.rk", include_str!("testcases/fails/basic/struct_bad_field_type/main.rk"), include_str!("testcases/fails/basic/struct_bad_field_type/main.rk.out"), include_str!("testcases/fails/basic/struct_bad_field_type/main.rk.stdout"));
+}
+#[test]
 fn testcases_fails_basic_fn_sig_main() {
     run("testcases/fails/basic/fn_sig/main.rk", include_str!("testcases/fails/basic/fn_sig/main.rk"), include_str!("testcases/fails/basic/fn_sig/main.rk.out"), include_str!("testcases/fails/basic/fn_sig/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_1_arg_fn_main() {
-    run("testcases/basic/1_arg_fn/main.rk", include_str!("testcases/basic/1_arg_fn/main.rk"), include_str!("testcases/basic/1_arg_fn/main.rk.out"), include_str!("testcases/basic/1_arg_fn/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_trait_monomorph_main() {
-    run("testcases/basic/trait_monomorph/main.rk", include_str!("testcases/basic/trait_monomorph/main.rk"), include_str!("testcases/basic/trait_monomorph/main.rk.out"), include_str!("testcases/basic/trait_monomorph/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_string_index_main() {
-    run("testcases/basic/string_index/main.rk", include_str!("testcases/basic/string_index/main.rk"), include_str!("testcases/basic/string_index/main.rk.out"), include_str!("testcases/basic/string_index/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_extern_main() {
-    run("testcases/basic/extern/main.rk", include_str!("testcases/basic/extern/main.rk"), include_str!("testcases/basic/extern/main.rk.out"), include_str!("testcases/basic/extern/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_trait_use_before_decl_main() {
-    run("testcases/basic/trait_use_before_decl/main.rk", include_str!("testcases/basic/trait_use_before_decl/main.rk"), include_str!("testcases/basic/trait_use_before_decl/main.rk.out"), include_str!("testcases/basic/trait_use_before_decl/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_spaced_dot_main() {
-    run("testcases/basic/spaced_dot/main.rk", include_str!("testcases/basic/spaced_dot/main.rk"), include_str!("testcases/basic/spaced_dot/main.rk.out"), include_str!("testcases/basic/spaced_dot/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_monomorph_main() {
-    run("testcases/basic/monomorph/main.rk", include_str!("testcases/basic/monomorph/main.rk"), include_str!("testcases/basic/monomorph/main.rk.out"), include_str!("testcases/basic/monomorph/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_main_main() {
-    run("testcases/basic/main/main.rk", include_str!("testcases/basic/main/main.rk"), include_str!("testcases/basic/main/main.rk.out"), include_str!("testcases/basic/main/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_fn_generic_sig_main() {
-    run("testcases/basic/fn_generic_sig/main.rk", include_str!("testcases/basic/fn_generic_sig/main.rk"), include_str!("testcases/basic/fn_generic_sig/main.rk.out"), include_str!("testcases/basic/fn_generic_sig/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_while_main() {
-    run("testcases/basic/while/main.rk", include_str!("testcases/basic/while/main.rk"), include_str!("testcases/basic/while/main.rk.out"), include_str!("testcases/basic/while/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_bool_false_main() {
-    run("testcases/basic/bool_false/main.rk", include_str!("testcases/basic/bool_false/main.rk"), include_str!("testcases/basic/bool_false/main.rk.out"), include_str!("testcases/basic/bool_false/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_let_main() {
-    run("testcases/basic/let/main.rk", include_str!("testcases/basic/let/main.rk"), include_str!("testcases/basic/let/main.rk.out"), include_str!("testcases/basic/let/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_bool_true_main() {
-    run("testcases/basic/bool_true/main.rk", include_str!("testcases/basic/bool_true/main.rk"), include_str!("testcases/basic/bool_true/main.rk.out"), include_str!("testcases/basic/bool_true/main.rk.stdout"));
 }
 #[test]
 fn testcases_basic_nested_array_main() {
     run("testcases/basic/nested_array/main.rk", include_str!("testcases/basic/nested_array/main.rk"), include_str!("testcases/basic/nested_array/main.rk.out"), include_str!("testcases/basic/nested_array/main.rk.stdout"));
 }
 #[test]
+fn testcases_basic_dot_assign_main() {
+    run("testcases/basic/dot_assign/main.rk", include_str!("testcases/basic/dot_assign/main.rk"), include_str!("testcases/basic/dot_assign/main.rk.out"), include_str!("testcases/basic/dot_assign/main.rk.stdout"));
+}
+#[test]
 fn testcases_basic_no_newline_end_main() {
     run("testcases/basic/no_newline_end/main.rk", include_str!("testcases/basic/no_newline_end/main.rk"), include_str!("testcases/basic/no_newline_end/main.rk.out"), include_str!("testcases/basic/no_newline_end/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_fn_arg_main() {
-    run("testcases/basic/fn_arg/main.rk", include_str!("testcases/basic/fn_arg/main.rk"), include_str!("testcases/basic/fn_arg/main.rk.out"), include_str!("testcases/basic/fn_arg/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_reassign_return_main() {
-    run("testcases/basic/reassign_return/main.rk", include_str!("testcases/basic/reassign_return/main.rk"), include_str!("testcases/basic/reassign_return/main.rk.out"), include_str!("testcases/basic/reassign_return/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_fn_arg_array_main() {
-    run("testcases/basic/fn_arg_array/main.rk", include_str!("testcases/basic/fn_arg_array/main.rk"), include_str!("testcases/basic/fn_arg_array/main.rk.out"), include_str!("testcases/basic/fn_arg_array/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_multi_style_struct_ctor_main() {
-    run("testcases/basic/multi_style_struct_ctor/main.rk", include_str!("testcases/basic/multi_style_struct_ctor/main.rk"), include_str!("testcases/basic/multi_style_struct_ctor/main.rk.out"), include_str!("testcases/basic/multi_style_struct_ctor/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_escaped_string_main() {
-    run("testcases/basic/escaped_string/main.rk", include_str!("testcases/basic/escaped_string/main.rk"), include_str!("testcases/basic/escaped_string/main.rk.out"), include_str!("testcases/basic/escaped_string/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_early_return_main() {
-    run("testcases/basic/early_return/main.rk", include_str!("testcases/basic/early_return/main.rk"), include_str!("testcases/basic/early_return/main.rk.out"), include_str!("testcases/basic/early_return/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_nested_struct_dect_multiline_main() {
-    run("testcases/basic/nested_struct_dect_multiline/main.rk", include_str!("testcases/basic/nested_struct_dect_multiline/main.rk"), include_str!("testcases/basic/nested_struct_dect_multiline/main.rk.out"), include_str!("testcases/basic/nested_struct_dect_multiline/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_impl_self_main() {
-    run("testcases/basic/impl_self/main.rk", include_str!("testcases/basic/impl_self/main.rk"), include_str!("testcases/basic/impl_self/main.rk.out"), include_str!("testcases/basic/impl_self/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_operator_precedence_main() {
-    run("testcases/basic/operator_precedence/main.rk", include_str!("testcases/basic/operator_precedence/main.rk"), include_str!("testcases/basic/operator_precedence/main.rk.out"), include_str!("testcases/basic/operator_precedence/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_reassign_main() {
-    run("testcases/basic/reassign/main.rk", include_str!("testcases/basic/reassign/main.rk"), include_str!("testcases/basic/reassign/main.rk.out"), include_str!("testcases/basic/reassign/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_simple_struct_main() {
-    run("testcases/basic/simple_struct/main.rk", include_str!("testcases/basic/simple_struct/main.rk"), include_str!("testcases/basic/simple_struct/main.rk.out"), include_str!("testcases/basic/simple_struct/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_struct_array_field_main() {
-    run("testcases/basic/struct_array_field/main.rk", include_str!("testcases/basic/struct_array_field/main.rk"), include_str!("testcases/basic/struct_array_field/main.rk.out"), include_str!("testcases/basic/struct_array_field/main.rk.stdout"));
 }
 #[test]
 fn testcases_basic_struct_impl_main() {
     run("testcases/basic/struct_impl/main.rk", include_str!("testcases/basic/struct_impl/main.rk"), include_str!("testcases/basic/struct_impl/main.rk.out"), include_str!("testcases/basic/struct_impl/main.rk.stdout"));
 }
 #[test]
-fn testcases_basic_nested_struct_main() {
-    run("testcases/basic/nested_struct/main.rk", include_str!("testcases/basic/nested_struct/main.rk"), include_str!("testcases/basic/nested_struct/main.rk.out"), include_str!("testcases/basic/nested_struct/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_indice_assign_main() {
-    run("testcases/basic/indice_assign/main.rk", include_str!("testcases/basic/indice_assign/main.rk"), include_str!("testcases/basic/indice_assign/main.rk.out"), include_str!("testcases/basic/indice_assign/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_fn_sig_main() {
-    run("testcases/basic/fn_sig/main.rk", include_str!("testcases/basic/fn_sig/main.rk"), include_str!("testcases/basic/fn_sig/main.rk.out"), include_str!("testcases/basic/fn_sig/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_recur_main() {
-    run("testcases/basic/recur/main.rk", include_str!("testcases/basic/recur/main.rk"), include_str!("testcases/basic/recur/main.rk.out"), include_str!("testcases/basic/recur/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_2_arg_fn_main() {
-    run("testcases/basic/2_arg_fn/main.rk", include_str!("testcases/basic/2_arg_fn/main.rk"), include_str!("testcases/basic/2_arg_fn/main.rk.out"), include_str!("testcases/basic/2_arg_fn/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_monomorph_in_trait_main() {
-    run("testcases/basic/monomorph_in_trait/main.rk", include_str!("testcases/basic/monomorph_in_trait/main.rk"), include_str!("testcases/basic/monomorph_in_trait/main.rk.out"), include_str!("testcases/basic/monomorph_in_trait/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_reassign_self_main() {
-    run("testcases/basic/reassign_self/main.rk", include_str!("testcases/basic/reassign_self/main.rk"), include_str!("testcases/basic/reassign_self/main.rk.out"), include_str!("testcases/basic/reassign_self/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_array_main() {
-    run("testcases/basic/array/main.rk", include_str!("testcases/basic/array/main.rk"), include_str!("testcases/basic/array/main.rk.out"), include_str!("testcases/basic/array/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_struct_index_main() {
-    run("testcases/basic/struct_index/main.rk", include_str!("testcases/basic/struct_index/main.rk"), include_str!("testcases/basic/struct_index/main.rk.out"), include_str!("testcases/basic/struct_index/main.rk.stdout"));
-}
-#[test]
-fn testcases_basic_op_func_main() {
-    run("testcases/basic/op_func/main.rk", include_str!("testcases/basic/op_func/main.rk"), include_str!("testcases/basic/op_func/main.rk.out"), include_str!("testcases/basic/op_func/main.rk.stdout"));
+fn testcases_basic_monomorph_main() {
+    run("testcases/basic/monomorph/main.rk", include_str!("testcases/basic/monomorph/main.rk"), include_str!("testcases/basic/monomorph/main.rk.out"), include_str!("testcases/basic/monomorph/main.rk.stdout"));
 }
 #[test]
 fn testcases_basic_negative_numbers_main() {
@@ -256,28 +124,84 @@ fn testcases_basic_negative_numbers_0_arg_fn_main() {
     run("testcases/basic/negative_numbers/0_arg_fn/main.rk", include_str!("testcases/basic/negative_numbers/0_arg_fn/main.rk"), include_str!("testcases/basic/negative_numbers/0_arg_fn/main.rk.out"), include_str!("testcases/basic/negative_numbers/0_arg_fn/main.rk.stdout"));
 }
 #[test]
-fn testcases_basic_self_returning_fn_main() {
-    run("testcases/basic/self_returning_fn/main.rk", include_str!("testcases/basic/self_returning_fn/main.rk"), include_str!("testcases/basic/self_returning_fn/main.rk.out"), include_str!("testcases/basic/self_returning_fn/main.rk.stdout"));
+fn testcases_basic_fn_generic_sig_main() {
+    run("testcases/basic/fn_generic_sig/main.rk", include_str!("testcases/basic/fn_generic_sig/main.rk"), include_str!("testcases/basic/fn_generic_sig/main.rk.out"), include_str!("testcases/basic/fn_generic_sig/main.rk.stdout"));
 }
 #[test]
-fn testcases_basic_0_arg_fn_main() {
-    run("testcases/basic/0_arg_fn/main.rk", include_str!("testcases/basic/0_arg_fn/main.rk"), include_str!("testcases/basic/0_arg_fn/main.rk.out"), include_str!("testcases/basic/0_arg_fn/main.rk.stdout"));
+fn testcases_basic_nested_struct_dect_multiline_main() {
+    run("testcases/basic/nested_struct_dect_multiline/main.rk", include_str!("testcases/basic/nested_struct_dect_multiline/main.rk"), include_str!("testcases/basic/nested_struct_dect_multiline/main.rk.out"), include_str!("testcases/basic/nested_struct_dect_multiline/main.rk.stdout"));
 }
 #[test]
-fn testcases_basic_simple_char_main() {
-    run("testcases/basic/simple_char/main.rk", include_str!("testcases/basic/simple_char/main.rk"), include_str!("testcases/basic/simple_char/main.rk.out"), include_str!("testcases/basic/simple_char/main.rk.stdout"));
+fn testcases_basic_bool_false_main() {
+    run("testcases/basic/bool_false/main.rk", include_str!("testcases/basic/bool_false/main.rk"), include_str!("testcases/basic/bool_false/main.rk.out"), include_str!("testcases/basic/bool_false/main.rk.stdout"));
 }
 #[test]
-fn testcases_basic_if_else_main() {
-    run("testcases/basic/if_else/main.rk", include_str!("testcases/basic/if_else/main.rk"), include_str!("testcases/basic/if_else/main.rk.out"), include_str!("testcases/basic/if_else/main.rk.stdout"));
+fn testcases_basic_let_main() {
+    run("testcases/basic/let/main.rk", include_str!("testcases/basic/let/main.rk"), include_str!("testcases/basic/let/main.rk.out"), include_str!("testcases/basic/let/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_main_main() {
+    run("testcases/basic/main/main.rk", include_str!("testcases/basic/main/main.rk"), include_str!("testcases/basic/main/main.rk.out"), include_str!("testcases/basic/main/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_spaced_dot_main() {
+    run("testcases/basic/spaced_dot/main.rk", include_str!("testcases/basic/spaced_dot/main.rk"), include_str!("testcases/basic/spaced_dot/main.rk.out"), include_str!("testcases/basic/spaced_dot/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_op_func_main() {
+    run("testcases/basic/op_func/main.rk", include_str!("testcases/basic/op_func/main.rk"), include_str!("testcases/basic/op_func/main.rk.out"), include_str!("testcases/basic/op_func/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_struct_index_main() {
+    run("testcases/basic/struct_index/main.rk", include_str!("testcases/basic/struct_index/main.rk"), include_str!("testcases/basic/struct_index/main.rk.out"), include_str!("testcases/basic/struct_index/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_impl_self_main() {
+    run("testcases/basic/impl_self/main.rk", include_str!("testcases/basic/impl_self/main.rk"), include_str!("testcases/basic/impl_self/main.rk.out"), include_str!("testcases/basic/impl_self/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_nested_struct_main() {
+    run("testcases/basic/nested_struct/main.rk", include_str!("testcases/basic/nested_struct/main.rk"), include_str!("testcases/basic/nested_struct/main.rk.out"), include_str!("testcases/basic/nested_struct/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_struct_array_field_main() {
+    run("testcases/basic/struct_array_field/main.rk", include_str!("testcases/basic/struct_array_field/main.rk"), include_str!("testcases/basic/struct_array_field/main.rk.out"), include_str!("testcases/basic/struct_array_field/main.rk.stdout"));
 }
 #[test]
 fn testcases_basic_multiline_struct_const_main() {
     run("testcases/basic/multiline_struct_const/main.rk", include_str!("testcases/basic/multiline_struct_const/main.rk"), include_str!("testcases/basic/multiline_struct_const/main.rk.out"), include_str!("testcases/basic/multiline_struct_const/main.rk.stdout"));
 }
 #[test]
-fn testcases_basic_dot_assign_main() {
-    run("testcases/basic/dot_assign/main.rk", include_str!("testcases/basic/dot_assign/main.rk"), include_str!("testcases/basic/dot_assign/main.rk.out"), include_str!("testcases/basic/dot_assign/main.rk.stdout"));
+fn testcases_basic_bool_true_main() {
+    run("testcases/basic/bool_true/main.rk", include_str!("testcases/basic/bool_true/main.rk"), include_str!("testcases/basic/bool_true/main.rk.out"), include_str!("testcases/basic/bool_true/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_reassign_self_main() {
+    run("testcases/basic/reassign_self/main.rk", include_str!("testcases/basic/reassign_self/main.rk"), include_str!("testcases/basic/reassign_self/main.rk.out"), include_str!("testcases/basic/reassign_self/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_trait_monomorph_main() {
+    run("testcases/basic/trait_monomorph/main.rk", include_str!("testcases/basic/trait_monomorph/main.rk"), include_str!("testcases/basic/trait_monomorph/main.rk.out"), include_str!("testcases/basic/trait_monomorph/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_1_arg_fn_main() {
+    run("testcases/basic/1_arg_fn/main.rk", include_str!("testcases/basic/1_arg_fn/main.rk"), include_str!("testcases/basic/1_arg_fn/main.rk.out"), include_str!("testcases/basic/1_arg_fn/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_simple_struct_main() {
+    run("testcases/basic/simple_struct/main.rk", include_str!("testcases/basic/simple_struct/main.rk"), include_str!("testcases/basic/simple_struct/main.rk.out"), include_str!("testcases/basic/simple_struct/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_self_returning_fn_main() {
+    run("testcases/basic/self_returning_fn/main.rk", include_str!("testcases/basic/self_returning_fn/main.rk"), include_str!("testcases/basic/self_returning_fn/main.rk.out"), include_str!("testcases/basic/self_returning_fn/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_string_index_main() {
+    run("testcases/basic/string_index/main.rk", include_str!("testcases/basic/string_index/main.rk"), include_str!("testcases/basic/string_index/main.rk.out"), include_str!("testcases/basic/string_index/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_if_else_main() {
+    run("testcases/basic/if_else/main.rk", include_str!("testcases/basic/if_else/main.rk"), include_str!("testcases/basic/if_else/main.rk.out"), include_str!("testcases/basic/if_else/main.rk.stdout"));
 }
 #[test]
 fn testcases_basic_negative_floats_main() {
@@ -286,4 +210,80 @@ fn testcases_basic_negative_floats_main() {
 #[test]
 fn testcases_basic_negative_floats_0_arg_fn_main() {
     run("testcases/basic/negative_floats/0_arg_fn/main.rk", include_str!("testcases/basic/negative_floats/0_arg_fn/main.rk"), include_str!("testcases/basic/negative_floats/0_arg_fn/main.rk.out"), include_str!("testcases/basic/negative_floats/0_arg_fn/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_reassign_return_main() {
+    run("testcases/basic/reassign_return/main.rk", include_str!("testcases/basic/reassign_return/main.rk"), include_str!("testcases/basic/reassign_return/main.rk.out"), include_str!("testcases/basic/reassign_return/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_escaped_string_main() {
+    run("testcases/basic/escaped_string/main.rk", include_str!("testcases/basic/escaped_string/main.rk"), include_str!("testcases/basic/escaped_string/main.rk.out"), include_str!("testcases/basic/escaped_string/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_monomorph_in_trait_main() {
+    run("testcases/basic/monomorph_in_trait/main.rk", include_str!("testcases/basic/monomorph_in_trait/main.rk"), include_str!("testcases/basic/monomorph_in_trait/main.rk.out"), include_str!("testcases/basic/monomorph_in_trait/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_recur_main() {
+    run("testcases/basic/recur/main.rk", include_str!("testcases/basic/recur/main.rk"), include_str!("testcases/basic/recur/main.rk.out"), include_str!("testcases/basic/recur/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_multi_style_struct_ctor_main() {
+    run("testcases/basic/multi_style_struct_ctor/main.rk", include_str!("testcases/basic/multi_style_struct_ctor/main.rk"), include_str!("testcases/basic/multi_style_struct_ctor/main.rk.out"), include_str!("testcases/basic/multi_style_struct_ctor/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_early_return_main() {
+    run("testcases/basic/early_return/main.rk", include_str!("testcases/basic/early_return/main.rk"), include_str!("testcases/basic/early_return/main.rk.out"), include_str!("testcases/basic/early_return/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_indice_assign_main() {
+    run("testcases/basic/indice_assign/main.rk", include_str!("testcases/basic/indice_assign/main.rk"), include_str!("testcases/basic/indice_assign/main.rk.out"), include_str!("testcases/basic/indice_assign/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_reassign_main() {
+    run("testcases/basic/reassign/main.rk", include_str!("testcases/basic/reassign/main.rk"), include_str!("testcases/basic/reassign/main.rk.out"), include_str!("testcases/basic/reassign/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_2_arg_fn_main() {
+    run("testcases/basic/2_arg_fn/main.rk", include_str!("testcases/basic/2_arg_fn/main.rk"), include_str!("testcases/basic/2_arg_fn/main.rk.out"), include_str!("testcases/basic/2_arg_fn/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_array_main() {
+    run("testcases/basic/array/main.rk", include_str!("testcases/basic/array/main.rk"), include_str!("testcases/basic/array/main.rk.out"), include_str!("testcases/basic/array/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_while_main() {
+    run("testcases/basic/while/main.rk", include_str!("testcases/basic/while/main.rk"), include_str!("testcases/basic/while/main.rk.out"), include_str!("testcases/basic/while/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_trait_use_before_decl_main() {
+    run("testcases/basic/trait_use_before_decl/main.rk", include_str!("testcases/basic/trait_use_before_decl/main.rk"), include_str!("testcases/basic/trait_use_before_decl/main.rk.out"), include_str!("testcases/basic/trait_use_before_decl/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_0_arg_fn_main() {
+    run("testcases/basic/0_arg_fn/main.rk", include_str!("testcases/basic/0_arg_fn/main.rk"), include_str!("testcases/basic/0_arg_fn/main.rk.out"), include_str!("testcases/basic/0_arg_fn/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_operator_precedence_main() {
+    run("testcases/basic/operator_precedence/main.rk", include_str!("testcases/basic/operator_precedence/main.rk"), include_str!("testcases/basic/operator_precedence/main.rk.out"), include_str!("testcases/basic/operator_precedence/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_extern_main() {
+    run("testcases/basic/extern/main.rk", include_str!("testcases/basic/extern/main.rk"), include_str!("testcases/basic/extern/main.rk.out"), include_str!("testcases/basic/extern/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_fn_arg_array_main() {
+    run("testcases/basic/fn_arg_array/main.rk", include_str!("testcases/basic/fn_arg_array/main.rk"), include_str!("testcases/basic/fn_arg_array/main.rk.out"), include_str!("testcases/basic/fn_arg_array/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_simple_char_main() {
+    run("testcases/basic/simple_char/main.rk", include_str!("testcases/basic/simple_char/main.rk"), include_str!("testcases/basic/simple_char/main.rk.out"), include_str!("testcases/basic/simple_char/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_fn_arg_main() {
+    run("testcases/basic/fn_arg/main.rk", include_str!("testcases/basic/fn_arg/main.rk"), include_str!("testcases/basic/fn_arg/main.rk.out"), include_str!("testcases/basic/fn_arg/main.rk.stdout"));
+}
+#[test]
+fn testcases_basic_fn_sig_main() {
+    run("testcases/basic/fn_sig/main.rk", include_str!("testcases/basic/fn_sig/main.rk"), include_str!("testcases/basic/fn_sig/main.rk.out"), include_str!("testcases/basic/fn_sig/main.rk.stdout"));
 }


### PR DESCRIPTION
This PR transforms all struct allocation from `alloca` instruction to `malloc` function call.
It adds two builtin functions `malloc: Int64 => String` and `free: String => Int64`
